### PR TITLE
🔒 [security] Add authorization check to lobby actions

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -145,14 +145,15 @@ io.on('connection', (socket) => {
   });
 
   socket.on('update_settings', ({ code, settings }: { code: string, settings: Partial<LobbySettings> }) => {
-     // TODO: Check if user is captain?
-     // LobbyService doesn't expose `isCaptain` check easily without fetching state.
-     // For now we trust the client, but ideally we should verify host.
-     lobbyService.updateSettings(code, settings);
+     if (lobbyService.isCaptain(code, user.id.toString())) {
+         lobbyService.updateSettings(code, settings);
+     }
   });
 
   socket.on('start_game', ({ code }: { code: string }) => {
-      lobbyService.startGame(code);
+      if (lobbyService.isCaptain(code, user.id.toString())) {
+          lobbyService.startGame(code);
+      }
   });
 
   socket.on('submit_action', ({ code, action }: { code: string, action: string }) => {
@@ -160,7 +161,9 @@ io.on('connection', (socket) => {
   });
 
   socket.on('reset_game', ({ code }: { code: string }) => {
-      lobbyService.resetGame(code);
+      if (lobbyService.isCaptain(code, user.id.toString())) {
+          lobbyService.resetGame(code);
+      }
   });
 
   socket.on('disconnect', () => {

--- a/server/services/lobbyService.ts
+++ b/server/services/lobbyService.ts
@@ -16,6 +16,13 @@ export class LobbyService {
     this.io = io;
   }
 
+  public isCaptain(code: string, playerId: string): boolean {
+    const lobby = this.lobbies.get(code);
+    if (!lobby) return false;
+    const player = lobby.players.find(p => p.id === playerId);
+    return player?.isCaptain || false;
+  }
+
   private generateCode(): string {
     let result = '';
     for (let i = 0; i < LOBBY_CODE_LENGTH; i++) {


### PR DESCRIPTION
This PR fixes a security vulnerability where any player in a lobby could reset the game, update settings, or start the game.

### 🎯 What:
Added server-side authorization checks to ensure only the lobby captain can perform administrative actions.

### ⚠️ Risk:
Unauthorized players could disrupt the game for others by resetting it or changing settings mid-game.

### 🛡️ Solution:
- Added `isCaptain(code: string, playerId: string): boolean` to `LobbyService`.
- Updated socket handlers in `server/index.ts` to use this check.
- Verified the logic with a test script.

---
*PR created automatically by Jules for task [147183353664163353](https://jules.google.com/task/147183353664163353) started by @the-asind*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Restricted lobby settings updates, game starts, and game resets to captains only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->