### PR TITLE
Feature: Gradual Results Reveal & Animations

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,8 +21,20 @@
                 secondaryBg: 'var(--tg-theme-secondary-bg-color, #2c2c2e)',
               }
             },
+            keyframes: {
+              fadeIn: {
+                '0%': { opacity: '0' },
+                '100%': { opacity: '1' },
+              },
+              slideUp: {
+                '0%': { transform: 'translateY(10px)', opacity: '0' },
+                '100%': { transform: 'translateY(0)', opacity: '1' },
+              }
+            },
             animation: {
               'pulse-fast': 'pulse 1s cubic-bezier(0.4, 0, 0.6, 1) infinite',
+              'fade-in': 'fadeIn 0.5s ease-out forwards',
+              'slide-up': 'slideUp 0.5s ease-out forwards',
             }
           }
         }

--- a/server/index.ts
+++ b/server/index.ts
@@ -135,6 +135,12 @@ io.on('connection', (socket) => {
       lobbyService.submitAction(code, user.id.toString(), action);
   });
 
+  socket.on('reveal_results', ({ code }: { code: string }) => {
+      if (lobbyService.isCaptain(code, user.id.toString())) {
+          lobbyService.revealResults(code, user.id.toString());
+      }
+  });
+
   socket.on('reset_game', ({ code }: { code: string }) => {
       if (lobbyService.isCaptain(code, user.id.toString())) {
           lobbyService.resetGame(code, user.id.toString());

--- a/server/services/lobbyService.ts
+++ b/server/services/lobbyService.ts
@@ -40,7 +40,8 @@ export class LobbyService {
       players: [{ ...host, isCaptain: true, status: 'waiting', isOnline: true }],
       status: GameStatus.LOBBY_WAITING,
       settings: settings,
-      scenario: null
+      scenario: null,
+      resultsRevealed: false
     };
 
     this.lobbies.set(code, initialState);
@@ -179,6 +180,7 @@ export class LobbyService {
     if (!lobby) return;
 
     lobby.status = GameStatus.PLAYER_INPUT;
+    lobby.resultsRevealed = false; // Reset for new round
 
     lobby.players.forEach(p => {
         p.status = 'waiting';
@@ -282,6 +284,7 @@ export class LobbyService {
 
          lobby.roundResult = result;
          lobby.status = GameStatus.RESULTS;
+         lobby.resultsRevealed = false; // Ensure it starts hidden
 
          lobby.players.forEach(p => {
              if (result.survivors.includes(p.id)) {
@@ -301,6 +304,16 @@ export class LobbyService {
      }
   }
 
+  public revealResults(code: string, playerId: string) {
+      if (!this.isCaptain(code, playerId)) return;
+      const lobby = this.lobbies.get(code)!;
+
+      if (lobby.status === GameStatus.RESULTS && !lobby.resultsRevealed) {
+          lobby.resultsRevealed = true;
+          this.emitUpdate(code);
+      }
+  }
+
   public resetGame(code: string, playerId: string) {
       if (!this.isCaptain(code, playerId)) return;
       const lobby = this.lobbies.get(code)!;
@@ -309,6 +322,7 @@ export class LobbyService {
       lobby.scenario = null;
       lobby.scenarioImage = undefined;
       lobby.roundResult = undefined;
+      lobby.resultsRevealed = false;
       lobby.players.forEach(p => {
           p.status = 'waiting';
           p.actionText = undefined;

--- a/services/socketService.ts
+++ b/services/socketService.ts
@@ -138,6 +138,10 @@ class SocketServiceImpl {
       this.socket?.emit('submit_action', { code, action });
   }
 
+  public revealResults(code: string) {
+      this.socket?.emit('reveal_results', { code });
+  }
+
   public resetGame(code: string) {
       this.socket?.emit('reset_game', { code });
   }

--- a/types.ts
+++ b/types.ts
@@ -67,6 +67,7 @@ export interface ServerGameState {
   scenario: ScenarioResponse | null; // Full object with secrets
   scenarioImage?: string;
   roundResult?: RoundResult;
+  resultsRevealed: boolean;
 }
 
 // Client-Side State (Safe)
@@ -78,6 +79,7 @@ export interface GameState {
   scenario: string | null; // Just the text!
   scenarioImage?: string;
   roundResult?: RoundResult;
+  resultsRevealed: boolean;
 }
 
 export interface RoundResult {


### PR DESCRIPTION
- Added `resultsRevealed` state to `GameState` and `ServerGameState`.
- Implemented `revealResults` action in `LobbyService` (Captain only).
- Added `reveal_results` socket event handler.
- Frontend:
    - Added typewriter effect for story text reveal.
    - Added "tap to speed up" logic (3 taps = 1.5x faster).
    - Added "SHOW RESULTS" button for Captain (appears after text reveal).
    - Added staggered slide-up animation for results table rows.
    - Updated Tailwind config with custom animations.

---
*PR created automatically by Jules for task [9245559130415678165](https://jules.google.com/task/9245559130415678165) started by @the-asind*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added progressive text reveal effect for results with typewriter-style animation.
  * Captain can control when results are displayed to all players via a new SHOW RESULTS button.
  * Tap results area to accelerate text reveal and trigger haptic feedback.
  * Added animated player status report displaying survival/death outcomes when results are revealed.
  * New PLAY AGAIN button for starting additional rounds.
  * Enhanced animations with new fadeIn and slideUp effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->