### PR TITLE
🧹 Extract inline Toast component

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -7,6 +7,7 @@ import { Button } from './components/Button';
 import { Input } from './components/Input';
 import { CodeInput } from './components/CodeInput';
 import { MarkdownDisplay } from './components/MarkdownDisplay';
+import { Toast } from './components/Toast';
 
 // Helper to count keys
 const getKeyCount = (): 0 | 1 | 2 => {
@@ -17,17 +18,6 @@ const getKeyCount = (): 0 | 1 | 2 => {
 };
 
 // Extracted Components
-const Toast = ({ toast }: { toast: { msg: string, type: 'success' | 'error' } | null }) => (
-    <div className={`fixed bottom-10 left-1/2 transform -translate-x-1/2 px-6 py-3 rounded-full shadow-2xl z-50 transition-all duration-300 ${toast ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5 pointer-events-none'}
-      ${toast?.type === 'error' ? 'bg-red-600' : 'bg-green-600'} text-white font-bold flex items-center gap-2`}>
-       {toast?.type === 'success' && (
-           <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-             <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
-           </svg>
-       )}
-       {toast?.msg}
-    </div>
-);
 
 interface SettingsModalProps {
     settingsNick: string;

--- a/components/Toast.tsx
+++ b/components/Toast.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+interface ToastProps {
+  toast: {
+    msg: string;
+    type: 'success' | 'error';
+  } | null;
+}
+
+export const Toast: React.FC<ToastProps> = ({ toast }) => (
+  <div className={`fixed bottom-10 left-1/2 transform -translate-x-1/2 px-6 py-3 rounded-full shadow-2xl z-50 transition-all duration-300 ${toast ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5 pointer-events-none'}
+    ${toast?.type === 'error' ? 'bg-red-600' : 'bg-green-600'} text-white font-bold flex items-center gap-2`}>
+     {toast?.type === 'success' && (
+         <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+           <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+         </svg>
+     )}
+     {toast?.msg}
+  </div>
+);


### PR DESCRIPTION
Extracted the inline `Toast` component from `App.tsx` into a new file `components/Toast.tsx`.
Formalized the component props with a `ToastProps` interface.
Updated `App.tsx` to use the extracted component.
This refactoring follows the existing project pattern of keeping components in the `components/` directory.

---
*PR created automatically by Jules for task [17556735981957416405](https://jules.google.com/task/17556735981957416405) started by @the-asind*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Toast notification component restructured for improved code organization. Success messages display with a green background and checkmark icon; error messages display with a red background. No changes to user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->